### PR TITLE
doc(readme): extend alias for common latex command with explicit scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ alias dexi='docker run --rm -t -i --user="$(id -u):$(id -g)" --net=none -v "$PWD
 
 # binary alias
 alias dexliveonfly='dex texliveonfly'
-alias dexpdf='dex pdflatex'
+alias dexpdf='dex pdftex' # for plain tex files
+alias dexpdflatex='dex pdflatex' # for tex files using \documentclass
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ alias dexi='docker run --rm -t -i --user="$(id -u):$(id -g)" --net=none -v "$PWD
 
 # binary alias
 alias dexliveonfly='dex texliveonfly'
-alias dexpdf='dex pdftex'
+alias dexpdf='dex pdflatex'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The goal of this PR is to avoid potential friction points encountered by regular latex users when onboarding this tool. 

- Make explicit the scope of the alias.
- Add the common-use command `pdflatex` command.